### PR TITLE
Protection against 0 length subheaders

### DIFF
--- a/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
+++ b/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
@@ -314,8 +314,7 @@ public class SasReader {
 				int base;
 				if (pageType == 2) {
 					row_count_p = row_count_fp;
-					int subhCount = IO.readInt(pageData, 20);
-					base = 24 + subhCount * 12;
+					base = 24 + subHeaders.size() * 12 + 12;
 					base = base + base % 8;
 				} else {
 					row_count_p = IO.readInt(pageData, 18);


### PR DESCRIPTION
When we actually populate the subHeaders list we keep track of which subheaders have length zero. By using the size of that list we can achieve the same expected result; however, can now better support zero length subheaders. The +12 at the end might not be accurate for Java (I've ported all the code to D); however, I've confirmed with what I'm working on, adding the additional length of a subheader to this was necessary.