### PR TITLE
Handle non-zero-aligned (a1=4) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.classpath
 /.settings
 /target
+
+.idea/
+*.iml

--- a/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
+++ b/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
@@ -104,6 +104,7 @@ public class SasReader {
 
 			SasHeader header = readHeader(is);
 			logger.info("({}) Header: {}", _file, header);
+			System.out.println(String.format("Header: %s", header.toString()));
 
 			readPages(is, header, callback);
 
@@ -431,12 +432,26 @@ public class SasReader {
 			throw new SasReaderException("Magic number mismatch!");
 		}
 
-		final int pageSize = IO.readInt(header, 200);
+        final byte byte32 = IO.readByte(header, 32);
+        final byte byte35 = IO.readByte(header, 35);
+        final byte byte37 = IO.readByte(header, 37);
+
+        int a2 = byte32 == 0x33 ? 4 : 0;
+        int a1 = byte35 == 0x33 ? 4 : 0;
+
+        boolean bigEndian = byte37 == 0;
+        boolean u64 = a2 == 4;
+
+        System.out.println(String.format("Endianness: %s", (bigEndian ? "big" : "little")));
+        System.out.println(String.format("U64? %s", String.valueOf(u64)));
+        System.out.println(String.format("a1=%d, a2=%d", a1, a2));
+
+		final int pageSize = IO.readInt(header, 200+a1);
 		if (pageSize < 0) {
 			throw new SasReaderException("Page size is negative: " + pageSize);
 		}
 
-		final int pageCount = IO.readInt(header, 204);
+		final int pageCount = IO.readInt(header, 204+a1);
 		if (pageCount < 1) {
 			throw new SasReaderException("Page count is not positive: "
 					+ pageCount);

--- a/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
+++ b/sas/src/main/java/org/eobjects/metamodel/sas/SasReader.java
@@ -104,7 +104,7 @@ public class SasReader {
 
 			SasHeader header = readHeader(is);
 			logger.info("({}) Header: {}", _file, header);
-			System.out.println(String.format("Header: %s", header.toString()));
+			logger.debug("Header: {}", header.toString());
 
 			readPages(is, header, callback);
 
@@ -442,9 +442,9 @@ public class SasReader {
         boolean bigEndian = byte37 == 0;
         boolean u64 = a2 == 4;
 
-        System.out.println(String.format("Endianness: %s", (bigEndian ? "big" : "little")));
-        System.out.println(String.format("U64? %s", String.valueOf(u64)));
-        System.out.println(String.format("a1=%d, a2=%d", a1, a2));
+        logger.debug("Endianness: {}", (bigEndian ? "big" : "little"));
+        logger.debug("U64? {}", String.valueOf(u64));
+        logger.debug("a1={}, a2={}", a1, a2);
 
 		final int pageSize = IO.readInt(header, 200+a1);
 		if (pageSize < 0) {


### PR DESCRIPTION
(This PR is a precursor to a larger one, which will handle date-time conversion.) 

I had some .sas7bdat files which weren't able to be parsed correctly by the base library (I can't share them, unfortunately).  Poking around the original reverse-engineered spec, I realized it was because they had an alignment parameter (the 'a1' parameter) which was non-zero.  

This PR contains a fix that works for me, on those files, as well as some .gitignore additions to handle my own IntelliJ-based development setup (and which might be useful to others). 